### PR TITLE
Fix: IDs that equal to 0 are allowed now.

### DIFF
--- a/js/bootstrap-tags.js
+++ b/js/bootstrap-tags.js
@@ -214,7 +214,7 @@
             return false;
         }
 
-        if(!value.id || !value.text) {
+        if(typeof value.id === 'undefined' || typeof value.text === 'undefined') {
             $self.options.onError(11, 'Not correct object format to create tag/pill');
             $.error('Not correct object format to create tag/pill');
         }


### PR DESCRIPTION
!value.id becomes true if id=0, therefore using typeof operator makes more sense for checking whether it's defined or not.

note: minified file should be changed as well.
